### PR TITLE
fix: jitpack에서 build 실패

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,8 @@
+jdk:
+  - openjdk17
+  
+before_install:
+  - source "$HOME/.sdkman/bin/sdkman-init.sh"
+  - sdk update
+  - sdk install java 17.0.2-zulu
+  - sdk use java 17.0.2-zulu


### PR DESCRIPTION
- jitpack은 jdk8을 기본값으로 사용하므로 현재 프로젝트에 맞는 jdk 설정