### PR TITLE
feat: PassportFilter, UserModel, CookieUtils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = 'com.moneyyummy'
-version = '0.2.3'
+version = '0.2.4'
 
 java {
     sourceCompatibility = '17'
@@ -44,7 +44,7 @@ publishing {
         maven(MavenPublication) {
             groupId = 'com.github.moneyyummy'
             artifactId = 'core-service'
-            version = '0.2.3'
+            version = '0.2.4'
 
             from components.java
         }

--- a/src/main/java/com/moneyyummy/coreservice/config/PassportFilterCondition.java
+++ b/src/main/java/com/moneyyummy/coreservice/config/PassportFilterCondition.java
@@ -1,0 +1,13 @@
+package com.moneyyummy.coreservice.config;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class PassportFilterCondition implements Condition {
+
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        return "true".equals(context.getEnvironment().getProperty("config.passport-filter"));
+    }
+}

--- a/src/main/java/com/moneyyummy/coreservice/filter/PassportFilter.java
+++ b/src/main/java/com/moneyyummy/coreservice/filter/PassportFilter.java
@@ -1,0 +1,48 @@
+package com.moneyyummy.coreservice.filter;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moneyyummy.coreservice.config.PassportFilterCondition;
+import com.moneyyummy.coreservice.model.UserModel;
+import com.moneyyummy.coreservice.util.JwtTokenUtils;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Conditional(PassportFilterCondition.class)
+public class PassportFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper mapper;
+    private final JwtTokenUtils jwtTokenUtils;
+
+    @Value("${moneyyummy.url.skip}")
+    private List<String> skipUrl;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String passport = request.getHeader("passport");
+        Claims claims = jwtTokenUtils.validateAndExtractTokenClaims(passport);
+        String userInfoDto = claims.get("userInfo", String.class);
+        UserModel userModel = mapper.readValue(userInfoDto, UserModel.class);
+        request.setAttribute("userModel", userModel);
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return skipUrl.stream()
+                .anyMatch(pattern -> pattern.equals(request.getRequestURI()));
+    }
+}

--- a/src/main/java/com/moneyyummy/coreservice/model/UserModel.java
+++ b/src/main/java/com/moneyyummy/coreservice/model/UserModel.java
@@ -1,0 +1,19 @@
+package com.moneyyummy.coreservice.model;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class UserModel {
+    private Long id;
+    private String nickname;
+    private String email;
+    private String job;
+    private String role;
+    private LocalDateTime createAt;
+    private LocalDateTime updateAt;
+
+    private String provider;
+    private String providerId;
+}

--- a/src/main/java/com/moneyyummy/coreservice/util/CookieUtils.java
+++ b/src/main/java/com/moneyyummy/coreservice/util/CookieUtils.java
@@ -1,0 +1,21 @@
+package com.moneyyummy.coreservice.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtils {
+
+    public ResponseCookie ofToken(String accessToken) {
+        return ResponseCookie.from(JwtTokenUtils.AUTHORIZATION, accessToken)
+                .path("/")
+                .maxAge(3600000)
+                .build();
+    }
+
+    public void addCookie(HttpServletResponse response, HttpCookie cookie) {
+        response.setHeader("Set-Cookie", cookie.toString());
+    }
+}

--- a/src/main/java/com/moneyyummy/coreservice/util/JwtTokenUtils.java
+++ b/src/main/java/com/moneyyummy/coreservice/util/JwtTokenUtils.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 @Component
 public class JwtTokenUtils {
 
-    private final static String AUTHORIZATION = "Authorization";
+    public static final String AUTHORIZATION = "Authorization";
 
     @Value("${token.secretKey}")
     private String secretKey;


### PR DESCRIPTION
feat: PassportFilter
- 'moneyyummy.url.skip' 값에 설정된 url 있으면 넘어감
- 'config.passport-filter' 값이 'true' 이면 스프링 빈으로 등록되어 Filter가 사용됨
- passport 토큰을 UserModel로 만들어서 request attribute에 넣어주는 필터

feat: CookieUtils
- Cookie 유틸리티 클래스 추가
- 코드 컨벤션 수정

feat: UserModel
- 모든 서비스에서 공통적으로 사용할 UserModel